### PR TITLE
UMD wrapper

### DIFF
--- a/src/swipeview.js
+++ b/src/swipeview.js
@@ -3,6 +3,22 @@
  * Released under MIT license, http://cubiq.org/license
  */
 
+// UMD wrapper
+(function (root, factory) {
+    if (typeof define === 'function' && define.amd) {
+        // AMD. Register as an anonymous module.
+        define([], factory);
+    } else if (typeof exports === 'object') {
+        // Node. Does not work with strict CommonJS, but
+        // only CommonJS-like environments that support module.exports,
+        // like Node.
+        module.exports = factory();
+    } else {
+        // Browser globals (root is window)
+        root.returnExports = factory();
+  }
+}(this, function () {
+
 var SwipeView = (function (window, document) {
   
 
@@ -673,3 +689,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
     return SwipeView;
 })(window, document);
+
+// End of UMD wrapper
+return SwipeView;
+}));


### PR DESCRIPTION
This makes SwipeView directly usable using Browserify, Require.js _and_ as with a `<script>`-tag. Also, it would be great to be able to find your package on `npmjs.com` for direct install with `npm` (alternately, I'm considering publishing from [our fork](https://github.com/visualspace/SwipeView/tree/peutetre) of your repo.

Source: https://github.com/umdjs/umd/blob/master/returnExports.js#L40
